### PR TITLE
Adds query entry point for reading the current Config value

### DIFF
--- a/contracts/cw721-marketplace-permissioned/schema/query_msg.json
+++ b/contracts/cw721-marketplace-permissioned/schema/query_msg.json
@@ -386,6 +386,19 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/cw721-marketplace-permissioned/schema/schema.json
+++ b/contracts/cw721-marketplace-permissioned/schema/schema.json
@@ -630,6 +630,19 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+          "type": "object",
+          "required": [
+            "config"
+          ],
+          "properties": {
+            "config": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw721-marketplace-permissioned/src/contract.rs
+++ b/contracts/cw721-marketplace-permissioned/src/contract.rs
@@ -9,8 +9,8 @@ use crate::execute::{
     execute_add_cw721, execute_remove_cw721, execute_update_config, execute_withdraw_fees
 };
 use crate::query::{
-    query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator, query_swaps_by_denom,
-    query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
+    query_config, query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator,
+    query_swaps_by_denom, query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{Config, CONFIG, SwapType};
@@ -102,6 +102,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
             to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+        }
+        QueryMsg::Config {} => {
+            to_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace-permissioned/src/msg.rs
+++ b/contracts/cw721-marketplace-permissioned/src/msg.rs
@@ -125,6 +125,9 @@ pub enum QueryMsg {
     /// Returns the details of the named swap, error if not created.
     /// Return type: DetailsResponse.
     Details { id: String },
+
+    /// Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)
+    Config {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/cw721-marketplace-permissioned/src/query.rs
+++ b/contracts/cw721-marketplace-permissioned/src/query.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Addr, Deps, Order, StdResult, Uint128};
 use cw_storage_plus::Bound;
 
 use crate::msg::{DetailsResponse, ListResponse};
-use crate::state::{all_swap_ids, CW721Swap, SWAPS, SwapType};
+use crate::state::{all_swap_ids, Config, CONFIG, CW721Swap, SWAPS, SwapType};
 use crate::utils::{calculate_page_params, PageParams};
 
 // Pagination query result format for filtered swap queries
@@ -298,4 +298,9 @@ pub fn query_swaps_by_payment_type(
     };
 
     Ok(res)
+}
+
+pub fn query_config(deps: Deps) -> StdResult<Config> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    Ok(config)
 }

--- a/contracts/cw721-marketplace-single-collection/schema/query_msg.json
+++ b/contracts/cw721-marketplace-single-collection/schema/query_msg.json
@@ -386,6 +386,19 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/cw721-marketplace-single-collection/schema/schema.json
+++ b/contracts/cw721-marketplace-single-collection/schema/schema.json
@@ -600,6 +600,19 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+          "type": "object",
+          "required": [
+            "config"
+          ],
+          "properties": {
+            "config": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw721-marketplace-single-collection/src/contract.rs
+++ b/contracts/cw721-marketplace-single-collection/src/contract.rs
@@ -9,8 +9,8 @@ use crate::execute::{
     execute_withdraw_fees,
 };
 use crate::query::{
-    query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator, query_swaps_by_denom,
-    query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
+    query_config, query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator,
+    query_swaps_by_denom, query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{Config, CONFIG, SwapType};
@@ -100,6 +100,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
             to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+        }
+        QueryMsg::Config {} => {
+            to_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace-single-collection/src/msg.rs
+++ b/contracts/cw721-marketplace-single-collection/src/msg.rs
@@ -118,6 +118,9 @@ pub enum QueryMsg {
     /// Returns the details of the named swap, error if not created.
     /// Return type: DetailsResponse.
     Details { id: String },
+
+    /// Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)
+    Config {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/cw721-marketplace-single-collection/src/query.rs
+++ b/contracts/cw721-marketplace-single-collection/src/query.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Addr, Deps, Order, StdResult, Uint128};
 use cw_storage_plus::Bound;
 
 use crate::msg::{DetailsResponse, ListResponse};
-use crate::state::{all_swap_ids, CW721Swap, CONFIG, SWAPS, SwapType};
+use crate::state::{all_swap_ids, Config, CONFIG, CW721Swap, SWAPS, SwapType};
 use crate::utils::{calculate_page_params, PageParams};
 
 // Pagination query result format for filtered swap queries
@@ -321,4 +321,9 @@ pub fn query_swaps_by_payment_type(
     };
 
     Ok(res)
+}
+
+pub fn query_config(deps: Deps) -> StdResult<Config> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    Ok(config)
 }

--- a/contracts/cw721-marketplace/schema/query_msg.json
+++ b/contracts/cw721-marketplace/schema/query_msg.json
@@ -386,6 +386,19 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/cw721-marketplace/schema/schema.json
+++ b/contracts/cw721-marketplace/schema/schema.json
@@ -592,6 +592,19 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)",
+          "type": "object",
+          "required": [
+            "config"
+          ],
+          "properties": {
+            "config": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw721-marketplace/src/contract.rs
+++ b/contracts/cw721-marketplace/src/contract.rs
@@ -9,8 +9,8 @@ use crate::execute::{
     execute_withdraw_fees,
 };
 use crate::query::{
-    query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator, query_swaps_by_denom,
-    query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
+    query_config, query_details, query_list, query_swap_total, query_swaps, query_swaps_by_creator,
+    query_swaps_by_denom, query_swaps_by_payment_type, query_swaps_by_price, query_swaps_of_token,
 };
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{Config, CONFIG, SwapType};
@@ -99,6 +99,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
             to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+        }
+        QueryMsg::Config {} => {
+            to_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace/src/msg.rs
+++ b/contracts/cw721-marketplace/src/msg.rs
@@ -118,6 +118,9 @@ pub enum QueryMsg {
     /// Returns the details of the named swap, error if not created.
     /// Return type: DetailsResponse.
     Details { id: String },
+
+    /// Query Config (useful for determining parameters for ExecuteMsg::UpdateConfig)
+    Config {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/cw721-marketplace/src/query.rs
+++ b/contracts/cw721-marketplace/src/query.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{Addr, Deps, Order, StdResult, Uint128};
 use cw_storage_plus::Bound;
 
 use crate::msg::{DetailsResponse, ListResponse};
-use crate::state::{all_swap_ids, CW721Swap, SWAPS, SwapType};
+use crate::state::{all_swap_ids, Config, CONFIG, CW721Swap, SWAPS, SwapType};
 use crate::utils::{calculate_page_params, PageParams};
 
 // Pagination query result format for filtered swap queries
@@ -298,4 +298,9 @@ pub fn query_swaps_by_payment_type(
     };
 
     Ok(res)
+}
+
+pub fn query_config(deps: Deps) -> StdResult<Config> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    Ok(config)
 }


### PR DESCRIPTION
This PR adds a query to get the value of the current `Config`, and it is added to all 3 packages (`cw721-marketplace`, `cw721-marketplace-permissioned` `cw721-marketplace-single-collection`)

The value of this function is to get the current Config parameters for use when updating (e.g. replacing) the current `Config` state with a new value (e.g. with `ExecuteMsg::UpdateConfig`)