### PR TITLE
Feature/marketplace fees no float

### DIFF
--- a/contracts/cw721-marketplace-permissioned/Cargo.lock
+++ b/contracts/cw721-marketplace-permissioned/Cargo.lock
@@ -10,21 +10,27 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "block-buffer"
@@ -43,6 +49,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
 
 [[package]]
 name = "byteorder"
@@ -70,22 +82,23 @@ checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e272708a9745dad8b591ef8a718571512130f2b39b33e3d7a27c558e3069394"
+checksum = "d8bb3c77c3b7ce472056968c745eb501c440fbc07be5004eba02782c35bfbbe3"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296db6a3caca5283425ae0cf347f4e46999ba3f6620dbea8939a0e00347831ce"
+checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
 dependencies = [
  "syn 1.0.91",
 ]
@@ -102,19 +115,24 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c59c0746057b1c1a018d7ded699da03b3db6b63de6cbb892f00d6301173b1af"
+checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
 dependencies = [
  "base64",
+ "bech32",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
+ "hex",
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.7",
+ "static_assertions",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -137,19 +155,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -331,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -366,6 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -378,14 +391,16 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -396,7 +411,7 @@ checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "thiserror",
@@ -411,19 +426,18 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -431,11 +445,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -447,12 +461,13 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -479,12 +494,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -520,14 +535,16 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.7",
+ "signature",
 ]
 
 [[package]]
@@ -537,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,9 +567,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -604,22 +627,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.6",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -654,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -677,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -743,19 +765,19 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -822,18 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +875,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/contracts/cw721-marketplace-permissioned/Cargo.lock
+++ b/contracts/cw721-marketplace-permissioned/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-marketplace-permissioned"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw721-marketplace-permissioned/Cargo.toml
+++ b/contracts/cw721-marketplace-permissioned/Cargo.toml
@@ -44,7 +44,6 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-#cosmwasm-std = "~1.0.0"
 cosmwasm-std = "~1.5.0"
 cosmwasm-storage = "~1.0.0"
 cw-storage-plus = "0.12"

--- a/contracts/cw721-marketplace-permissioned/Cargo.toml
+++ b/contracts/cw721-marketplace-permissioned/Cargo.toml
@@ -44,7 +44,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "~1.0.0"
+#cosmwasm-std = "~1.0.0"
+cosmwasm-std = "~1.5.0"
 cosmwasm-storage = "~1.0.0"
 cw-storage-plus = "0.12"
 cw2 = "0.12"

--- a/contracts/cw721-marketplace-permissioned/Cargo.toml
+++ b/contracts/cw721-marketplace-permissioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-marketplace-permissioned"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   "johhonn <jjj.may377@gmail.com>",
   "Drew Taylor <drew.taylor@philabs.xyz>"

--- a/contracts/cw721-marketplace-permissioned/src/contract.rs
+++ b/contracts/cw721-marketplace-permissioned/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     Binary, Deps, DepsMut, entry_point, Env, MessageInfo, Reply, Response, StdResult, 
-    SubMsgResult, to_binary,
+    SubMsgResult, to_json_binary,
 };
 
 use crate::execute::{
@@ -74,37 +74,37 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::List { start_after, limit } => {
-            to_binary(&query_list(deps, start_after, limit)?)
+            to_json_binary(&query_list(deps, start_after, limit)?)
         },
         QueryMsg::Details { id } => {
-            to_binary(&query_details(deps, id)?)
+            to_json_binary(&query_details(deps, id)?)
         },
         QueryMsg::GetTotal { swap_type } => {
-            to_binary(&query_swap_total(deps, swap_type)?)
+            to_json_binary(&query_swap_total(deps, swap_type)?)
         },
         QueryMsg::GetOffers { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
         },
         QueryMsg::GetListings { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
         }
         QueryMsg::ListingsOfToken { token_id, cw721, swap_type, page, limit } => {
-            to_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
         }
         QueryMsg::SwapsOf { address, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPrice { min, max, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByDenom { payment_token, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
         }
         QueryMsg::Config {} => {
-            to_binary(&query_config(deps)?)
+            to_json_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace-permissioned/src/execute.rs
+++ b/contracts/cw721-marketplace-permissioned/src/execute.rs
@@ -168,11 +168,12 @@ pub fn execute_finish(
 
     // Remove all swaps for this token_id 
     // (as they're no longer valid)
+    let swap_data = swap;
     let swaps: Result<Vec<(String, CW721Swap)>, cosmwasm_std::StdError> = SWAPS
         .range(deps.storage, None, None, Order::Ascending)
         .collect();
     for swap in swaps.unwrap().iter() {
-        if swap.1.token_id == msg.token_id {
+        if swap.1.token_id == swap_data.token_id && swap.1.nft_contract == swap_data.nft_contract {
             SWAPS.remove(deps.storage, &swap.0);
         }
     }

--- a/contracts/cw721-marketplace-permissioned/src/execute.rs
+++ b/contracts/cw721-marketplace-permissioned/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Order, Response,
-    to_binary, WasmMsg,
+    to_json_binary, WasmMsg,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -308,7 +308,7 @@ pub fn execute_withdraw_fees(
 
         let cw20_transfer: CosmosMsg = cosmwasm_std::CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: msg.payment_token.unwrap().into(),
-            msg: to_binary(&cw20_transfer_msg)?,
+            msg: to_json_binary(&cw20_transfer_msg)?,
             funds: vec![],
         });
         cw20_transfer

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
@@ -16,9 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap_with_fees, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg, 
-    // XXX TODO (drew): fix fee splitter
-    WithdrawMsg,
+    ExecuteMsg, QueryMsg, SwapMsg, WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -134,17 +132,12 @@ fn test_fees_native() {
     // cw721_owner has received the ARCH amount
     let balance_query: Coin = bank_query(&mut app, &cw721_owner);
     assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
-    // XXX TODO (drew): fix fee splitter
-    // assert_eq!(balance_query.amount, Uint128::from(1000000000000000000_u128));
     
     // swap_inst has retained its fee
     let balance_query: Coin = bank_query(&mut app, &swap_inst);
-    // XXX TODO (drew): fix fee splitter
     assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
-    // assert_eq!(balance_query.amount, Uint128::from(0_u128));
 
     // swap_admin can withdraw native fees
-    // XXX TODO (drew): fix fee splitter
     let withdraw_msg = WithdrawMsg {
         amount: Uint128::from(10000000000000000_u128), 
         denom: String::from(DENOM),
@@ -160,7 +153,6 @@ fn test_fees_native() {
         .unwrap();
     
     // swap_admin received its withdrawn fees
-    // XXX TODO (drew): fix fee splitter
     let balance_query: Coin = bank_query(&mut app, &swap_admin);
     assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
 }
@@ -270,8 +262,6 @@ fn test_fees_cw20() {
         }
     ).unwrap();
     assert_eq!(balance_query.balance, Uint128::from(99000_u32));
-    // XXX TODO (drew): fix fee splitter
-    // assert_eq!(balance_query.balance, Uint128::from(100000_u32));
 
     // swap_inst has retained its fee
     let balance_query: BalanceResponse = query(
@@ -281,12 +271,9 @@ fn test_fees_cw20() {
             address: swap_inst.clone().to_string()
         }
     ).unwrap();
-    // XXX TODO (drew): fix fee splitter
     assert_eq!(balance_query.balance, Uint128::from(1000_u32));
-    // assert_eq!(balance_query.balance, Uint128::from(0_u32));
 
     // swap_admin can withdraw cw20 fees
-    // XXX TODO (drew): fix fee splitter
     let withdraw_msg = WithdrawMsg {
         amount: Uint128::from(1000_u32),
         denom: String::from(DENOM),
@@ -302,7 +289,6 @@ fn test_fees_cw20() {
         .unwrap();
     
     // swap_admin received its withdrawn cw20 fees
-    // XXX TODO (drew): fix fee splitter
     let balance_query: BalanceResponse = query(
         &mut app,
         cw20_inst,

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
@@ -16,7 +16,9 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap_with_fees, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg, WithdrawMsg,
+    ExecuteMsg, QueryMsg, SwapMsg, 
+    // XXX TODO (drew): fix fee splitter
+    // WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -130,30 +132,36 @@ fn test_fees_native() {
 
     // cw721_owner has received the ARCH amount
     let balance_query: Coin = bank_query(&mut app, &cw721_owner);
-    assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
+    // assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
+    // XXX TODO (drew): fix fee splitter
+    assert_eq!(balance_query.amount, Uint128::from(1000000000000000000_u128));
     
     // swap_inst has retained its fee
     let balance_query: Coin = bank_query(&mut app, &swap_inst);
-    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    // XXX TODO (drew): fix fee splitter
+    // assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(0_u128));
 
     // swap_admin can withdraw native fees
-    let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(10000000000000000_u128), 
-        denom: String::from(DENOM),
-        payment_token: None,
-    };
-    let _res = app
-        .execute_contract(
-            swap_admin.clone(), 
-            swap_inst.clone(), 
-            &ExecuteMsg::Withdraw(withdraw_msg), 
-            &[]
-        )
-        .unwrap();
+    // XXX TODO (drew): fix fee splitter
+    // let withdraw_msg = WithdrawMsg {
+    //     amount: Uint128::from(10000000000000000_u128), 
+    //     denom: String::from(DENOM),
+    //     payment_token: None,
+    // };
+    // let _res = app
+    //     .execute_contract(
+    //         swap_admin.clone(), 
+    //         swap_inst.clone(), 
+    //         &ExecuteMsg::Withdraw(withdraw_msg), 
+    //         &[]
+    //     )
+    //     .unwrap();
     
     // swap_admin received its withdrawn fees
-    let balance_query: Coin = bank_query(&mut app, &swap_admin);
-    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    // XXX TODO (drew): fix fee splitter
+    // let balance_query: Coin = bank_query(&mut app, &swap_admin);
+    // assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
 }
 
 // Receive cw20 tokens and release upon approval
@@ -260,7 +268,9 @@ fn test_fees_cw20() {
             address: cw721_owner.to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(99000_u32));
+    // assert_eq!(balance_query.balance, Uint128::from(99000_u32));
+    // XXX TODO (drew): fix fee splitter
+    assert_eq!(balance_query.balance, Uint128::from(100000_u32));
 
     // swap_inst has retained its fee
     let balance_query: BalanceResponse = query(
@@ -270,30 +280,34 @@ fn test_fees_cw20() {
             address: swap_inst.clone().to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    // XXX TODO (drew): fix fee splitter
+    // assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(0_u32));
 
     // swap_admin can withdraw cw20 fees
-    let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(1000_u32),
-        denom: String::from(DENOM),
-        payment_token: Some(cw20_inst.clone()),
-    };
-    let _res = app
-        .execute_contract(
-            swap_admin.clone(), 
-            swap_inst, 
-            &ExecuteMsg::Withdraw(withdraw_msg), 
-            &[]
-        )
-        .unwrap();
+    // XXX TODO (drew): fix fee splitter
+    // let withdraw_msg = WithdrawMsg {
+    //     amount: Uint128::from(1000_u32),
+    //     denom: String::from(DENOM),
+    //     payment_token: Some(cw20_inst.clone()),
+    // };
+    // let _res = app
+    //     .execute_contract(
+    //         swap_admin.clone(), 
+    //         swap_inst, 
+    //         &ExecuteMsg::Withdraw(withdraw_msg), 
+    //         &[]
+    //     )
+    //     .unwrap();
     
     // swap_admin received its withdrawn cw20 fees
-    let balance_query: BalanceResponse = query(
-        &mut app,
-        cw20_inst,
-        Cw20QueryMsg::Balance {
-            address: swap_admin.to_string()
-        }
-    ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    // XXX TODO (drew): fix fee splitter
+    // let balance_query: BalanceResponse = query(
+    //     &mut app,
+    //     cw20_inst,
+    //     Cw20QueryMsg::Balance {
+    //         address: swap_admin.to_string()
+    //     }
+    // ).unwrap();
+    // assert_eq!(balance_query.balance, Uint128::from(1000_u32));
 }

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
@@ -18,7 +18,7 @@ use crate::integration_tests::util::{
 use crate::msg::{
     ExecuteMsg, QueryMsg, SwapMsg, 
     // XXX TODO (drew): fix fee splitter
-    // WithdrawMsg,
+    WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -133,36 +133,36 @@ fn test_fees_native() {
 
     // cw721_owner has received the ARCH amount
     let balance_query: Coin = bank_query(&mut app, &cw721_owner);
-    // assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
     // XXX TODO (drew): fix fee splitter
-    assert_eq!(balance_query.amount, Uint128::from(1000000000000000000_u128));
+    // assert_eq!(balance_query.amount, Uint128::from(1000000000000000000_u128));
     
     // swap_inst has retained its fee
     let balance_query: Coin = bank_query(&mut app, &swap_inst);
     // XXX TODO (drew): fix fee splitter
-    // assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
-    assert_eq!(balance_query.amount, Uint128::from(0_u128));
+    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    // assert_eq!(balance_query.amount, Uint128::from(0_u128));
 
     // swap_admin can withdraw native fees
     // XXX TODO (drew): fix fee splitter
-    // let withdraw_msg = WithdrawMsg {
-    //     amount: Uint128::from(10000000000000000_u128), 
-    //     denom: String::from(DENOM),
-    //     payment_token: None,
-    // };
-    // let _res = app
-    //     .execute_contract(
-    //         swap_admin.clone(), 
-    //         swap_inst.clone(), 
-    //         &ExecuteMsg::Withdraw(withdraw_msg), 
-    //         &[]
-    //     )
-    //     .unwrap();
+    let withdraw_msg = WithdrawMsg {
+        amount: Uint128::from(10000000000000000_u128), 
+        denom: String::from(DENOM),
+        payment_token: None,
+    };
+    let _res = app
+        .execute_contract(
+            swap_admin.clone(), 
+            swap_inst.clone(), 
+            &ExecuteMsg::Withdraw(withdraw_msg), 
+            &[]
+        )
+        .unwrap();
     
     // swap_admin received its withdrawn fees
     // XXX TODO (drew): fix fee splitter
-    // let balance_query: Coin = bank_query(&mut app, &swap_admin);
-    // assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    let balance_query: Coin = bank_query(&mut app, &swap_admin);
+    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
 }
 
 // Receive cw20 tokens and release upon approval
@@ -269,9 +269,9 @@ fn test_fees_cw20() {
             address: cw721_owner.to_string()
         }
     ).unwrap();
-    // assert_eq!(balance_query.balance, Uint128::from(99000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(99000_u32));
     // XXX TODO (drew): fix fee splitter
-    assert_eq!(balance_query.balance, Uint128::from(100000_u32));
+    // assert_eq!(balance_query.balance, Uint128::from(100000_u32));
 
     // swap_inst has retained its fee
     let balance_query: BalanceResponse = query(
@@ -282,33 +282,33 @@ fn test_fees_cw20() {
         }
     ).unwrap();
     // XXX TODO (drew): fix fee splitter
-    // assert_eq!(balance_query.balance, Uint128::from(1000_u32));
-    assert_eq!(balance_query.balance, Uint128::from(0_u32));
+    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    // assert_eq!(balance_query.balance, Uint128::from(0_u32));
 
     // swap_admin can withdraw cw20 fees
     // XXX TODO (drew): fix fee splitter
-    // let withdraw_msg = WithdrawMsg {
-    //     amount: Uint128::from(1000_u32),
-    //     denom: String::from(DENOM),
-    //     payment_token: Some(cw20_inst.clone()),
-    // };
-    // let _res = app
-    //     .execute_contract(
-    //         swap_admin.clone(), 
-    //         swap_inst, 
-    //         &ExecuteMsg::Withdraw(withdraw_msg), 
-    //         &[]
-    //     )
-    //     .unwrap();
+    let withdraw_msg = WithdrawMsg {
+        amount: Uint128::from(1000_u32),
+        denom: String::from(DENOM),
+        payment_token: Some(cw20_inst.clone()),
+    };
+    let _res = app
+        .execute_contract(
+            swap_admin.clone(), 
+            swap_inst, 
+            &ExecuteMsg::Withdraw(withdraw_msg), 
+            &[]
+        )
+        .unwrap();
     
     // swap_admin received its withdrawn cw20 fees
     // XXX TODO (drew): fix fee splitter
-    // let balance_query: BalanceResponse = query(
-    //     &mut app,
-    //     cw20_inst,
-    //     Cw20QueryMsg::Balance {
-    //         address: swap_admin.to_string()
-    //     }
-    // ).unwrap();
-    // assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    let balance_query: BalanceResponse = query(
+        &mut app,
+        cw20_inst,
+        Cw20QueryMsg::Balance {
+            address: swap_admin.to_string()
+        }
+    ).unwrap();
+    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
 }

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/util.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/util.rs
@@ -4,8 +4,8 @@ use std::collections::HashSet;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::{
-    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_binary, Querier, QueryRequest, 
-    StdError, to_binary, Uint128, WasmQuery,
+    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_json, Querier, QueryRequest, 
+    StdError, to_json_binary, Uint128, WasmQuery,
 };
 use cw_multi_test::{
     App, Contract, ContractWrapper, Executor,
@@ -139,7 +139,7 @@ pub fn query<M,T>(router: &mut App, target_contract: Addr, msg: M) -> Result<T, 
     {
         router.wrap().query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: target_contract.to_string(),
-            msg: to_binary(&msg).unwrap(),
+            msg: to_json_binary(&msg).unwrap(),
         }))
     }
 
@@ -148,8 +148,8 @@ pub fn bank_query(app: &App, address: &Addr) -> Coin {
         address: address.to_string(), 
         denom: DENOM.to_string() 
     });
-    let res = app.raw_query(&to_binary(&req).unwrap()).unwrap().unwrap();
-    let balance: BalanceResponseBank = from_binary(&res).unwrap();
+    let res = app.raw_query(&to_json_binary(&req).unwrap()).unwrap().unwrap();
+    let balance: BalanceResponseBank = from_json(&res).unwrap();
     return balance.amount;
 }
 

--- a/contracts/cw721-marketplace-permissioned/src/utils.rs
+++ b/contracts/cw721-marketplace-permissioned/src/utils.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_binary, 
-    QueryRequest, to_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_json, 
+    QueryRequest, to_json_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -45,7 +45,7 @@ pub fn query_name_owner(
     };
     let req = QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: cw721.to_string(),
-        msg: to_binary(&query_msg).unwrap(),
+        msg: to_json_binary(&query_msg).unwrap(),
     });
     let res: OwnerOfResponse = deps.querier.query(&req)?;
     Ok(res)
@@ -160,8 +160,8 @@ pub fn check_contract_balance_ok(
         address: swap_instance.to_string(),
         denom: required_denom,
     });
-    let res = deps.querier.raw_query(&to_binary(&req).unwrap()).unwrap().unwrap();
-    let query: BalanceResponse = from_binary(&res).unwrap();
+    let res = deps.querier.raw_query(&to_json_binary(&req).unwrap()).unwrap().unwrap();
+    let query: BalanceResponse = from_json(res).unwrap();
     let balance: Coin = query.amount;
     if balance.amount.u128() < required_amount {
         return Err(ContractError::InsufficientBalance {});
@@ -189,7 +189,7 @@ pub fn handle_swap_transfers(
 
         let cw20_callback: CosmosMsg = WasmMsg::Execute {
             contract_addr: details.payment_token.clone().unwrap().into(),
-            msg: to_binary(&token_transfer_msg)?,
+            msg: to_json_binary(&token_transfer_msg)?,
             funds: vec![],
         }
         .into();
@@ -219,7 +219,7 @@ pub fn handle_swap_transfers(
 
         let cw20_callback: CosmosMsg = WasmMsg::Execute {
             contract_addr: details.payment_token.clone().unwrap().into(),
-            msg: to_binary(&token_transfer_msg)?,
+            msg: to_json_binary(&token_transfer_msg)?,
             funds: vec![],
         }
         .into();
@@ -233,7 +233,7 @@ pub fn handle_swap_transfers(
 
     let cw721_callback: CosmosMsg = WasmMsg::Execute {
         contract_addr: details.nft_contract.to_string(),
-        msg: to_binary(&nft_transfer_msg)?,
+        msg: to_json_binary(&nft_transfer_msg)?,
         funds: vec![],
     }
     .into();
@@ -244,31 +244,26 @@ pub fn handle_swap_transfers(
     Ok(msgs)
 }
 
-// XXX TODO: Fix this function to use cosmwasm_std::Decimal
-// because `f64` is not allowed in cosmwasm < 0.35
-// Below we try using Decimal; but it doesn't work with cw20s
-// which have will have unknown decimal precision
 pub fn fee_split(
     deps: &DepsMut,
     swap_price: Uint128,
 ) -> Result<FeeSplit, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    // Convert fees to decimal percentange
-    let fees = Decimal::percent(config.fees);
-
-    // Calculate retained fees
-    let marketplace = Decimal::from_ratio(
-        fees.atomics(),
-        swap_price
-    );
-    if (marketplace.atomics()) >= swap_price.into() {
+    let marketplace: Uint128 = fee_percentage(swap_price, config.fees);
+    if marketplace.u128() >= swap_price.into() {
         return Err(ContractError::InvalidInput {});
     }
-
-    let seller: u128 = swap_price.u128() - marketplace.atomics().u128();
+    let seller: Uint128 = Uint128::from(swap_price.u128() - marketplace.u128());
     let result = FeeSplit { 
-        marketplace: marketplace.atomics(),
-        seller: Uint128::from(seller),
+        marketplace,
+        seller,
     };
     Ok(result)
+}
+
+pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
+    let share = Decimal::percent(share_percent);
+    let amount_decimal = Decimal::from_atomics(amount, 0).unwrap();
+    let fee = amount_decimal * share;
+    fee.to_uint_floor()
 }

--- a/contracts/cw721-marketplace-permissioned/src/utils.rs
+++ b/contracts/cw721-marketplace-permissioned/src/utils.rs
@@ -244,20 +244,28 @@ pub fn handle_swap_transfers(
     Ok(msgs)
 }
 
+// XXX TODO: Fix this function to use cosmwasm_std::Decimal
+// because `f64` is not allowed in cosmwasm < 0.35
 pub fn fee_split(
-    deps: &DepsMut,
+    _deps: &DepsMut,
     swap_price: Uint128,
 ) -> Result<FeeSplit, ContractError> {
-    let config = CONFIG.load(deps.storage)?;
-    let fees: f64 = config.fees as f64 / 100_f64;
-    let marketplace: f64 = (swap_price.u128() as f64) * fees;
-    if (marketplace as u128) >= swap_price.into() {
-        return Err(ContractError::InvalidInput {});
-    }
-    let seller: u128 = swap_price.u128() - marketplace as u128;
-    let result = FeeSplit { 
-        marketplace: Uint128::from(marketplace as u128),
-        seller: Uint128::from(seller),
+    // let config = CONFIG.load(deps.storage)?;
+
+    // let fees: f64 = config.fees as f64 / 100_f64;
+    // let marketplace: f64 = (swap_price.u128() as f64) * fees;
+    // if (marketplace as u128) >= swap_price.into() {
+    //     return Err(ContractError::InvalidInput {});
+    // }
+
+    // let seller: u128 = swap_price.u128() - marketplace as u128;
+    // let result = FeeSplit { 
+    //     marketplace: Uint128::from(marketplace as u128),
+    //     seller: Uint128::from(seller),
+    // };
+    let result = FeeSplit {
+        marketplace: Uint128::from(0_u128),
+        seller: swap_price,
     };
     Ok(result)
 }

--- a/contracts/cw721-marketplace-single-collection/Cargo.lock
+++ b/contracts/cw721-marketplace-single-collection/Cargo.lock
@@ -10,21 +10,27 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "block-buffer"
@@ -43,6 +49,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
 
 [[package]]
 name = "byteorder"
@@ -70,22 +82,23 @@ checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e272708a9745dad8b591ef8a718571512130f2b39b33e3d7a27c558e3069394"
+checksum = "d8bb3c77c3b7ce472056968c745eb501c440fbc07be5004eba02782c35bfbbe3"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296db6a3caca5283425ae0cf347f4e46999ba3f6620dbea8939a0e00347831ce"
+checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
 dependencies = [
  "syn 1.0.91",
 ]
@@ -102,19 +115,24 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c59c0746057b1c1a018d7ded699da03b3db6b63de6cbb892f00d6301173b1af"
+checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
 dependencies = [
  "base64",
+ "bech32",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
+ "hex",
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.7",
+ "static_assertions",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -137,19 +155,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -331,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -366,6 +378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -378,14 +391,16 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -396,7 +411,7 @@ checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
  "thiserror",
@@ -411,19 +426,18 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -431,11 +445,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -447,12 +461,13 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -479,12 +494,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -520,14 +535,16 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.7",
+ "signature",
 ]
 
 [[package]]
@@ -537,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,9 +567,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -604,22 +627,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.6",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -654,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -677,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -743,19 +765,19 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -822,18 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +875,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/contracts/cw721-marketplace-single-collection/Cargo.toml
+++ b/contracts/cw721-marketplace-single-collection/Cargo.toml
@@ -44,7 +44,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "~1.0.0"
+cosmwasm-std = "~1.5.0"
 cosmwasm-storage = "~1.0.0"
 cw-storage-plus = "0.12"
 cw2 = "0.12"

--- a/contracts/cw721-marketplace-single-collection/src/contract.rs
+++ b/contracts/cw721-marketplace-single-collection/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     Binary, Deps, DepsMut, entry_point, Env, MessageInfo, Reply, Response, StdResult, 
-    SubMsgResult, to_binary,
+    SubMsgResult, to_json_binary,
 };
 
 use crate::execute::{
@@ -72,37 +72,37 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::List { start_after, limit } => {
-            to_binary(&query_list(deps, start_after, limit)?)
+            to_json_binary(&query_list(deps, start_after, limit)?)
         },
         QueryMsg::Details { id } => {
-            to_binary(&query_details(deps, id)?)
+            to_json_binary(&query_details(deps, id)?)
         },
         QueryMsg::GetTotal { swap_type } => {
-            to_binary(&query_swap_total(deps, swap_type)?)
+            to_json_binary(&query_swap_total(deps, swap_type)?)
         },
         QueryMsg::GetOffers { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
         },
         QueryMsg::GetListings { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
         }
         QueryMsg::ListingsOfToken { token_id, swap_type, page, limit } => {
-            to_binary(&query_swaps_of_token(deps, token_id, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_of_token(deps, token_id, swap_type, page, limit)?)
         }
         QueryMsg::SwapsOf { address, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPrice { min, max, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByDenom { payment_token, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
         }
         QueryMsg::Config {} => {
-            to_binary(&query_config(deps)?)
+            to_json_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace-single-collection/src/execute.rs
+++ b/contracts/cw721-marketplace-single-collection/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Order, Response,
-    to_binary, WasmMsg,
+    to_json_binary, WasmMsg,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -250,7 +250,7 @@ pub fn execute_withdraw_fees(
 
         let cw20_transfer: CosmosMsg = cosmwasm_std::CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: msg.payment_token.unwrap().into(),
-            msg: to_binary(&cw20_transfer_msg)?,
+            msg: to_json_binary(&cw20_transfer_msg)?,
             funds: vec![],
         });
         cw20_transfer

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/util.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/util.rs
@@ -4,8 +4,8 @@ use std::collections::HashSet;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::{
-    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_binary, Querier, QueryRequest, 
-    StdError, to_binary, Uint128, WasmQuery,
+    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_json, Querier, QueryRequest, 
+    StdError, to_json_binary, Uint128, WasmQuery,
 };
 use cw_multi_test::{
     App, Contract, ContractWrapper, Executor,
@@ -139,7 +139,7 @@ pub fn query<M,T>(router: &mut App, target_contract: Addr, msg: M) -> Result<T, 
     {
         router.wrap().query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: target_contract.to_string(),
-            msg: to_binary(&msg).unwrap(),
+            msg: to_json_binary(&msg).unwrap(),
         }))
     }
 
@@ -148,8 +148,8 @@ pub fn bank_query(app: &App, address: &Addr) -> Coin {
         address: address.to_string(), 
         denom: DENOM.to_string() 
     });
-    let res = app.raw_query(&to_binary(&req).unwrap()).unwrap().unwrap();
-    let balance: BalanceResponseBank = from_binary(&res).unwrap();
+    let res = app.raw_query(&to_json_binary(&req).unwrap()).unwrap().unwrap();
+    let balance: BalanceResponseBank = from_json(&res).unwrap();
     return balance.amount;
 }
 

--- a/contracts/cw721-marketplace-single-collection/src/utils.rs
+++ b/contracts/cw721-marketplace-single-collection/src/utils.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, DepsMut, Env, from_binary, QueryRequest, 
-    to_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_binary, 
+    QueryRequest, to_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -249,14 +249,21 @@ pub fn fee_split(
     swap_price: Uint128,
 ) -> Result<FeeSplit, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    let fees: f64 = config.fees as f64 / 100_f64;
-    let marketplace: f64 = (swap_price.u128() as f64) * fees;
-    if (marketplace as u128) >= swap_price.into() {
+    // Convert fees to decimal percentange
+    let fees = Decimal::percent(config.fees);
+
+    // Calculate retained fees
+    let marketplace = Decimal::from_ratio(
+        fees.atomics(),
+        swap_price
+    );
+    if (marketplace.atomics()) >= swap_price.into() {
         return Err(ContractError::InvalidInput {});
     }
-    let seller: u128 = swap_price.u128() - marketplace as u128;
+
+    let seller: u128 = swap_price.u128() - marketplace.atomics().u128();
     let result = FeeSplit { 
-        marketplace: Uint128::from(marketplace as u128),
+        marketplace: marketplace.atomics(),
         seller: Uint128::from(seller),
     };
     Ok(result)

--- a/contracts/cw721-marketplace/Cargo.lock
+++ b/contracts/cw721-marketplace/Cargo.lock
@@ -16,15 +16,21 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "block-buffer"
@@ -43,6 +49,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bnum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
 
 [[package]]
 name = "byteorder"
@@ -103,19 +115,24 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c59c0746057b1c1a018d7ded699da03b3db6b63de6cbb892f00d6301173b1af"
+checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
 dependencies = [
  "base64",
+ "bech32",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
+ "hex",
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.7",
+ "static_assertions",
  "thiserror",
- "uint",
 ]
 
 [[package]]
@@ -136,12 +153,6 @@ checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -688,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -831,18 +842,6 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/contracts/cw721-marketplace/Cargo.toml
+++ b/contracts/cw721-marketplace/Cargo.toml
@@ -44,7 +44,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = "~1.0.0"
+cosmwasm-std = "~1.5.0"
 cosmwasm-storage = "~1.0.0"
 cw-storage-plus = "0.12"
 cw2 = "0.12"

--- a/contracts/cw721-marketplace/src/contract.rs
+++ b/contracts/cw721-marketplace/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     Binary, Deps, DepsMut, entry_point, Env, MessageInfo, Reply, Response, StdResult, 
-    SubMsgResult, to_binary,
+    SubMsgResult, to_json_binary,
 };
 
 use crate::execute::{
@@ -71,37 +71,37 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::List { start_after, limit } => {
-            to_binary(&query_list(deps, start_after, limit)?)
+            to_json_binary(&query_list(deps, start_after, limit)?)
         },
         QueryMsg::Details { id } => {
-            to_binary(&query_details(deps, id)?)
+            to_json_binary(&query_details(deps, id)?)
         },
         QueryMsg::GetTotal { swap_type } => {
-            to_binary(&query_swap_total(deps, swap_type)?)
+            to_json_binary(&query_swap_total(deps, swap_type)?)
         },
         QueryMsg::GetOffers { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Offer, page, limit)?)
         },
         QueryMsg::GetListings { page, limit } => {
-            to_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
+            to_json_binary(&query_swaps(deps, SwapType::Sale, page, limit)?)
         }
         QueryMsg::ListingsOfToken { token_id, cw721, swap_type, page, limit } => {
-            to_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
         }
         QueryMsg::SwapsOf { address, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPrice { min, max, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByDenom { payment_token, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
         }
         QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
-            to_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
         }
         QueryMsg::Config {} => {
-            to_binary(&query_config(deps)?)
+            to_json_binary(&query_config(deps)?)
         }
     }
 }

--- a/contracts/cw721-marketplace/src/execute.rs
+++ b/contracts/cw721-marketplace/src/execute.rs
@@ -134,7 +134,7 @@ pub fn execute_finish(
             .collect();
         
         fee_split(&deps, funds[0].amount).unwrap()
-    } else { 
+    } else {
         fee_split(&deps, swap.price).unwrap()
     };
 

--- a/contracts/cw721-marketplace/src/execute.rs
+++ b/contracts/cw721-marketplace/src/execute.rs
@@ -160,11 +160,12 @@ pub fn execute_finish(
 
     // Remove all swaps for this token_id 
     // (as they're no longer valid)
+    let swap_data = swap;
     let swaps: Result<Vec<(String, CW721Swap)>, cosmwasm_std::StdError> = SWAPS
         .range(deps.storage, None, None, Order::Ascending)
         .collect();
     for swap in swaps.unwrap().iter() {
-        if swap.1.token_id == msg.token_id {
+        if swap.1.token_id == swap_data.token_id && swap.1.nft_contract == swap_data.nft_contract {
             SWAPS.remove(deps.storage, &swap.0);
         }
     }

--- a/contracts/cw721-marketplace/src/execute.rs
+++ b/contracts/cw721-marketplace/src/execute.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, Order, Response,
-    to_binary, WasmMsg,
+    to_json_binary, WasmMsg,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -252,7 +252,7 @@ pub fn execute_withdraw_fees(
         
         let cw20_transfer: CosmosMsg = cosmwasm_std::CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: msg.payment_token.unwrap().into(),
-            msg: to_binary(&cw20_transfer_msg)?,
+            msg: to_json_binary(&cw20_transfer_msg)?,
             funds: vec![],
         });
         cw20_transfer

--- a/contracts/cw721-marketplace/src/integration_tests/util.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/util.rs
@@ -4,8 +4,8 @@ use std::collections::HashSet;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::{
-    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_binary, Querier, QueryRequest, 
-    StdError, to_binary, Uint128, WasmQuery,
+    Addr, BalanceResponse as BalanceResponseBank, BankQuery, Coin, Empty, from_json, Querier, QueryRequest, 
+    StdError, to_json_binary, Uint128, WasmQuery,
 };
 use cw_multi_test::{
     App, Contract, ContractWrapper, Executor,
@@ -137,7 +137,7 @@ pub fn query<M,T>(router: &mut App, target_contract: Addr, msg: M) -> Result<T, 
     {
         router.wrap().query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: target_contract.to_string(),
-            msg: to_binary(&msg).unwrap(),
+            msg: to_json_binary(&msg).unwrap(),
         }))
     }
 
@@ -146,8 +146,8 @@ pub fn bank_query(app: &App, address: &Addr) -> Coin {
         address: address.to_string(), 
         denom: DENOM.to_string() 
     });
-    let res = app.raw_query(&to_binary(&req).unwrap()).unwrap().unwrap();
-    let balance: BalanceResponseBank = from_binary(&res).unwrap();
+    let res = app.raw_query(&to_json_binary(&req).unwrap()).unwrap().unwrap();
+    let balance: BalanceResponseBank = from_json(&res).unwrap();
     return balance.amount;
 }
 

--- a/contracts/cw721-marketplace/src/utils.rs
+++ b/contracts/cw721-marketplace/src/utils.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, DepsMut, Env, from_binary, QueryRequest, 
-    to_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_binary, 
+    QueryRequest, to_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
 use cw20::Cw20ExecuteMsg;
@@ -249,14 +249,21 @@ pub fn fee_split(
     swap_price: Uint128,
 ) -> Result<FeeSplit, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    let fees: f64 = config.fees as f64 / 100_f64;
-    let marketplace: f64 = (swap_price.u128() as f64) * fees;
-    if (marketplace as u128) >= swap_price.into() {
+    // Convert fees to decimal percentange
+    let fees = Decimal::percent(config.fees);
+
+    // Calculate retained fees
+    let marketplace = Decimal::from_ratio(
+        fees.atomics(),
+        swap_price
+    );
+    if (marketplace.atomics()) >= swap_price.into() {
         return Err(ContractError::InvalidInput {});
     }
-    let seller: u128 = swap_price.u128() - marketplace as u128;
+
+    let seller: u128 = swap_price.u128() - marketplace.atomics().u128();
     let result = FeeSplit { 
-        marketplace: Uint128::from(marketplace as u128),
+        marketplace: marketplace.atomics(),
         seller: Uint128::from(seller),
     };
     Ok(result)


### PR DESCRIPTION
This branch replaces f64 float types with `cosmwasm_std::Decimal` types, and adapts the fee splitter math to work with the new type.

Upon merging, this make the fee splitter module (which powers marketplace fees) work again; as previously, this code was commented out so it could be deployed on Constantine-3