### PR TITLE
Improvements for paginated swap queries and execute_finish

### DIFF
--- a/contracts/cw721-marketplace-permissioned/schema/execute_msg.json
+++ b/contracts/cw721-marketplace-permissioned/schema/execute_msg.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "finish": {
-          "$ref": "#/definitions/SwapMsg"
+          "$ref": "#/definitions/FinishSwapMsg"
         }
       },
       "additionalProperties": false
@@ -196,6 +196,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "SwapMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace-permissioned/schema/schema.json
+++ b/contracts/cw721-marketplace-permissioned/schema/schema.json
@@ -83,7 +83,7 @@
           ],
           "properties": {
             "finish": {
-              "$ref": "#/definitions/SwapMsg"
+              "$ref": "#/definitions/FinishSwapMsg"
             }
           },
           "additionalProperties": false
@@ -215,6 +215,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "InstantiateMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace-permissioned/src/execute.rs
+++ b/contracts/cw721-marketplace-permissioned/src/execute.rs
@@ -66,7 +66,7 @@ pub fn execute_create(
 
     Ok(Response::new()
         .add_attribute("action", "create")
-        .add_attribute("swap", msg.id)
+        .add_attribute("swap_id", msg.id)
         .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
         .add_attribute("price", swap.price))
@@ -191,6 +191,7 @@ pub fn execute_finish(
 
     Ok(Response::new()
         .add_attribute("action", "finish")
+        .add_attribute("swap_id", swap.id)
         .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
         .add_attribute("price", swap.price)

--- a/contracts/cw721-marketplace-permissioned/src/execute.rs
+++ b/contracts/cw721-marketplace-permissioned/src/execute.rs
@@ -9,7 +9,9 @@ use crate::state::{CW721Swap, Config, CONFIG, SWAPS, SwapType};
 use crate::utils::{
     check_sent_required_payment, fee_split, handle_swap_transfers, query_name_owner,
 };
-use crate::msg::{CancelMsg, SwapMsg, UpdateMsg, UpdateNftMsg, WithdrawMsg};
+use crate::msg::{
+    CancelMsg, FinishSwapMsg, SwapMsg, UpdateMsg, UpdateNftMsg, WithdrawMsg
+};
 use crate::error::ContractError;
 
 pub fn execute_create(
@@ -40,6 +42,7 @@ pub fn execute_create(
         return Err(ContractError::InvalidPaymentToken {});
     }
     let swap = CW721Swap {
+        id: msg.id.clone(),
         creator: info.sender,
         nft_contract: msg.cw721,
         payment_token: msg.payment_token,
@@ -63,6 +66,7 @@ pub fn execute_create(
 
     Ok(Response::new()
         .add_attribute("action", "create")
+        .add_attribute("swap", msg.id)
         .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
         .add_attribute("price", swap.price))
@@ -85,6 +89,7 @@ pub fn execute_update(
     // payment_token and swap_type should not be updatable
     // E.g. only price and expiration can be modified
     let swap = CW721Swap {
+        id: swap.id,
         creator: swap.creator,
         nft_contract: swap.nft_contract,
         payment_token: swap.payment_token,
@@ -107,7 +112,7 @@ pub fn execute_finish(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: SwapMsg,
+    msg: FinishSwapMsg,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     let swap = SWAPS.load(deps.storage, &msg.id)?;
@@ -116,7 +121,7 @@ pub fn execute_finish(
         return Err(ContractError::Expired {});
     }
     // If no cw721 permission, revert
-    if !config.cw721.contains(&msg.cw721) {
+    if !config.cw721.contains(&swap.nft_contract) {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -168,7 +173,7 @@ pub fn execute_finish(
 
     // Remove all swaps for this token_id 
     // (as they're no longer valid)
-    let swap_data = swap;
+    let swap_data = swap.clone();
     let swaps: Result<Vec<(String, CW721Swap)>, cosmwasm_std::StdError> = SWAPS
         .range(deps.storage, None, None, Order::Ascending)
         .collect();
@@ -178,17 +183,17 @@ pub fn execute_finish(
         }
     }
     
-    let payment_token: String = if msg.payment_token.is_some() {
-        msg.payment_token.unwrap().to_string()
+    let payment_token: String = if swap.payment_token.is_some() {
+        swap.payment_token.unwrap().to_string()
     } else {
         config.denom
     };
 
     Ok(Response::new()
         .add_attribute("action", "finish")
-        .add_attribute("token_id", msg.token_id)
+        .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
-        .add_attribute("price", msg.price)
+        .add_attribute("price", swap.price)
         .add_messages(transfer_results))
 }
 

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap_with_fees, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg, WithdrawMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg, WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -73,7 +73,9 @@ fn test_fees_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -210,7 +212,9 @@ fn test_fees_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/invalid_payment.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/invalid_payment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -71,7 +71,9 @@ fn test_invalid_payment_native() {
         price: Uint128::from(5000000000000000000_u128), // 5 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -256,7 +258,9 @@ fn test_invalid_payment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -368,7 +372,9 @@ fn test_invalid_payment_cw20_offer() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/offer.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/offer.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     create_cw20, create_cw721, create_swap, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -86,7 +86,9 @@ fn test_cw20_offer_accepted() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/overpayment.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/overpayment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -72,7 +72,9 @@ fn test_overpayment_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -240,7 +242,9 @@ fn test_overpayment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/sale.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/sale.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -72,7 +72,9 @@ fn test_buy_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -186,7 +188,9 @@ fn test_buy_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/update.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/update.rs
@@ -49,7 +49,7 @@ fn test_updating_sales() {
         .execute_contract(cw721_owner.clone(), nft.clone(), &mint_msg, &[])
         .unwrap();
 
-    // Create a SwapMsg for creating / finishing a swap
+    // Create a SwapMsg for creating
     let swap_id: String = "firstswap".to_string();
     let creation_msg = SwapMsg {
         id: swap_id.clone(),

--- a/contracts/cw721-marketplace-permissioned/src/msg.rs
+++ b/contracts/cw721-marketplace-permissioned/src/msg.rs
@@ -17,7 +17,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     // Swap entry points
     Create(SwapMsg),
-    Finish(SwapMsg),
+    Finish(FinishSwapMsg),
     Cancel(CancelMsg),
     Update(UpdateMsg),
 
@@ -48,6 +48,11 @@ pub struct SwapMsg {
     pub price: Uint128,
     pub swap_type: SwapType,
 }
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FinishSwapMsg {
+    pub id: String,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct UpdateNftMsg {
     pub cw721: Addr,

--- a/contracts/cw721-marketplace-permissioned/src/state.rs
+++ b/contracts/cw721-marketplace-permissioned/src/state.rs
@@ -25,6 +25,7 @@ pub enum SwapType {
 // swap type of false equals offer, swap type of true equals buy
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CW721Swap {
+    pub id: String,
     pub creator: Addr,
     pub nft_contract: Addr,
     pub payment_token: Option<Addr>,

--- a/contracts/cw721-marketplace-single-collection/Cargo.lock
+++ b/contracts/cw721-marketplace-single-collection/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-marketplace-single-collection"
-version = "0.0.1"
+version = "0.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw721-marketplace-single-collection/schema/execute_msg.json
+++ b/contracts/cw721-marketplace-single-collection/schema/execute_msg.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "finish": {
-          "$ref": "#/definitions/SwapMsg"
+          "$ref": "#/definitions/FinishSwapMsg"
         }
       },
       "additionalProperties": false
@@ -169,6 +169,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "SwapMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace-single-collection/schema/schema.json
+++ b/contracts/cw721-marketplace-single-collection/schema/schema.json
@@ -80,7 +80,7 @@
           ],
           "properties": {
             "finish": {
-              "$ref": "#/definitions/SwapMsg"
+              "$ref": "#/definitions/FinishSwapMsg"
             }
           },
           "additionalProperties": false
@@ -188,6 +188,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "InstantiateMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace-single-collection/src/execute.rs
+++ b/contracts/cw721-marketplace-single-collection/src/execute.rs
@@ -9,7 +9,9 @@ use crate::state::{CW721Swap, Config, CONFIG, SWAPS, SwapType};
 use crate::utils::{
     check_sent_required_payment, fee_split, handle_swap_transfers, query_name_owner,
 };
-use crate::msg::{CancelMsg, SwapMsg, UpdateMsg, WithdrawMsg};
+use crate::msg::{
+    CancelMsg, FinishSwapMsg, SwapMsg, UpdateMsg, WithdrawMsg
+};
 use crate::error::ContractError;
 
 pub fn execute_create(
@@ -35,6 +37,7 @@ pub fn execute_create(
         return Err(ContractError::InvalidPaymentToken {});
     }
     let swap = CW721Swap {
+        id: msg.id.clone(),
         creator: info.sender,
         nft_contract: config.cw721,
         payment_token: msg.payment_token,
@@ -58,6 +61,7 @@ pub fn execute_create(
 
     Ok(Response::new()
         .add_attribute("action", "create")
+        .add_attribute("swap_id", msg.id)
         .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
         .add_attribute("price", swap.price))
@@ -80,6 +84,7 @@ pub fn execute_update(
     // payment_token and swap_type should not be updatable
     // E.g. only price and expiration can be modified
     let swap = CW721Swap {
+        id: swap.id,
         creator: swap.creator,
         nft_contract: swap.nft_contract,
         payment_token: swap.payment_token,
@@ -102,7 +107,7 @@ pub fn execute_finish(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    msg: SwapMsg,
+    msg: FinishSwapMsg,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     let swap = SWAPS.load(deps.storage, &msg.id)?;
@@ -159,26 +164,28 @@ pub fn execute_finish(
 
     // Remove all swaps for this token_id 
     // (as they're no longer valid)
+    let swap_data = swap.clone();
     let swaps: Result<Vec<(String, CW721Swap)>, cosmwasm_std::StdError> = SWAPS
         .range(deps.storage, None, None, Order::Ascending)
         .collect();
     for swap in swaps.unwrap().iter() {
-        if swap.1.token_id == msg.token_id {
+        if swap.1.token_id == swap_data.token_id {
             SWAPS.remove(deps.storage, &swap.0);
         }
     }
     
-    let payment_token: String = if msg.payment_token.is_some() {
-        msg.payment_token.unwrap().to_string()
+    let payment_token: String = if swap.payment_token.is_some() {
+        swap.payment_token.unwrap().to_string()
     } else {
         config.denom
     };
 
     Ok(Response::new()
         .add_attribute("action", "finish")
-        .add_attribute("token_id", msg.token_id)
+        .add_attribute("swap_id", swap.id)
+        .add_attribute("token_id", swap.token_id)
         .add_attribute("payment_token", payment_token)
-        .add_attribute("price", msg.price)
+        .add_attribute("price", swap.price)
         .add_messages(transfer_results))
 }
 

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/fees.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap_with_fees, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg, WithdrawMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg, WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -72,7 +72,9 @@ fn test_fees_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -207,7 +209,9 @@ fn test_fees_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/invalid_payment.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/invalid_payment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -70,7 +70,9 @@ fn test_invalid_payment_native() {
         price: Uint128::from(5000000000000000000_u128), // 5 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -253,7 +255,9 @@ fn test_invalid_payment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -364,7 +368,9 @@ fn test_invalid_payment_cw20_offer() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/offer.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/offer.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     create_cw20, create_cw721, create_swap, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -85,7 +85,9 @@ fn test_cw20_offer_accepted() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/overpayment.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/overpayment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -71,7 +71,9 @@ fn test_overpayment_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -237,7 +239,9 @@ fn test_overpayment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/sale.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/sale.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -71,7 +71,9 @@ fn test_buy_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -183,7 +185,9 @@ fn test_buy_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/update.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/update.rs
@@ -49,7 +49,7 @@ fn test_updating_sales() {
         .execute_contract(cw721_owner.clone(), nft.clone(), &mint_msg, &[])
         .unwrap();
 
-    // Create a SwapMsg for creating / finishing a swap
+    // Create a SwapMsg for creating a swap
     let swap_id: String = "firstswap".to_string();
     let creation_msg = SwapMsg {
         id: swap_id.clone(),

--- a/contracts/cw721-marketplace-single-collection/src/msg.rs
+++ b/contracts/cw721-marketplace-single-collection/src/msg.rs
@@ -17,7 +17,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     // Swap entry points
     Create(SwapMsg),
-    Finish(SwapMsg),
+    Finish(FinishSwapMsg),
     Cancel(CancelMsg),
     Update(UpdateMsg),
 
@@ -45,6 +45,11 @@ pub struct SwapMsg {
     pub price: Uint128,
     pub swap_type: SwapType,
 }
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FinishSwapMsg {
+    pub id: String,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct WithdrawMsg { 
     pub amount: Uint128, 

--- a/contracts/cw721-marketplace-single-collection/src/state.rs
+++ b/contracts/cw721-marketplace-single-collection/src/state.rs
@@ -25,6 +25,7 @@ pub enum SwapType {
 // swap type of false equals offer, swap type of true equals buy
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CW721Swap {
+    pub id: String,
     pub creator: Addr,
     pub nft_contract: Addr,
     pub payment_token: Option<Addr>,

--- a/contracts/cw721-marketplace/Cargo.lock
+++ b/contracts/cw721-marketplace/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-marketplace"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw721-marketplace/schema/execute_msg.json
+++ b/contracts/cw721-marketplace/schema/execute_msg.json
@@ -21,7 +21,7 @@
       ],
       "properties": {
         "finish": {
-          "$ref": "#/definitions/SwapMsg"
+          "$ref": "#/definitions/FinishSwapMsg"
         }
       },
       "additionalProperties": false
@@ -165,6 +165,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "SwapMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace/schema/schema.json
+++ b/contracts/cw721-marketplace/schema/schema.json
@@ -76,7 +76,7 @@
           ],
           "properties": {
             "finish": {
-              "$ref": "#/definitions/SwapMsg"
+              "$ref": "#/definitions/FinishSwapMsg"
             }
           },
           "additionalProperties": false
@@ -184,6 +184,17 @@
           "additionalProperties": false
         }
       ]
+    },
+    "FinishSwapMsg": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
     },
     "InstantiateMsg": {
       "type": "object",

--- a/contracts/cw721-marketplace/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/fees.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap_with_fees, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg, WithdrawMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg, WithdrawMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -73,7 +73,9 @@ fn test_fees_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -210,7 +212,9 @@ fn test_fees_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace/src/integration_tests/invalid_payment.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/invalid_payment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -71,7 +71,9 @@ fn test_invalid_payment_native() {
         price: Uint128::from(5000000000000000000_u128), // 5 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -256,7 +258,9 @@ fn test_invalid_payment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -368,7 +372,9 @@ fn test_invalid_payment_cw20_offer() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace/src/integration_tests/offer.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/offer.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     create_cw20, create_cw721, create_swap, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -86,7 +86,9 @@ fn test_cw20_offer_accepted() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     let _res = app
         .execute_contract(cw20_owner.clone(), swap_inst.clone(), &ExecuteMsg::Create(creation_msg), &[])

--- a/contracts/cw721-marketplace/src/integration_tests/overpayment.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/overpayment.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, SwapMsg,
 };
 use crate::state::{SwapType};
 
@@ -72,7 +72,9 @@ fn test_overpayment_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -240,7 +242,9 @@ fn test_overpayment_cw20() {
         price: Uint128::from(100000_u32),
         swap_type:SwapType::Offer,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace/src/integration_tests/sale.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/sale.rs
@@ -16,7 +16,7 @@ use crate::integration_tests::util::{
     bank_query, create_cw20, create_cw721, create_swap, mint_native, mock_app, query,
 };
 use crate::msg::{
-    ExecuteMsg, QueryMsg, SwapMsg,
+    ExecuteMsg, FinishSwapMsg, QueryMsg, SwapMsg,
 };
 use crate::query::PageResult;
 use crate::state::{SwapType};
@@ -72,7 +72,9 @@ fn test_buy_native() {
         price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {
@@ -186,7 +188,9 @@ fn test_buy_cw20() {
         price: Uint128::from(100000_u32),
         swap_type: SwapType::Sale,
     };
-    let finish_msg = creation_msg.clone();
+    let finish_msg = FinishSwapMsg {
+        id: creation_msg.id.clone(),
+    };
 
     // Seller (cw721_owner) must approve the swap contract to spend their NFT
     let nft_approve_msg = Cw721ExecuteMsg::Approve::<Extension> {

--- a/contracts/cw721-marketplace/src/integration_tests/update.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/update.rs
@@ -49,7 +49,7 @@ fn test_updating_sales() {
         .execute_contract(cw721_owner.clone(), nft.clone(), &mint_msg, &[])
         .unwrap();
 
-    // Create a SwapMsg for creating / finishing a swap
+    // Create a SwapMsg for creating a swap
     let swap_id: String = "firstswap".to_string();
     let creation_msg = SwapMsg {
         id: swap_id.clone(),

--- a/contracts/cw721-marketplace/src/msg.rs
+++ b/contracts/cw721-marketplace/src/msg.rs
@@ -16,7 +16,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     // Swap entry points
     Create(SwapMsg),
-    Finish(SwapMsg),
+    Finish(FinishSwapMsg),
     Cancel(CancelMsg),
     Update(UpdateMsg),
 
@@ -45,6 +45,11 @@ pub struct SwapMsg {
     pub price: Uint128,
     pub swap_type: SwapType,
 }
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FinishSwapMsg {
+    pub id: String,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct WithdrawMsg { 
     pub amount: Uint128, 

--- a/contracts/cw721-marketplace/src/state.rs
+++ b/contracts/cw721-marketplace/src/state.rs
@@ -24,6 +24,7 @@ pub enum SwapType {
 // swap type of false equals offer, swap type of true equals buy
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CW721Swap {
+    pub id: String,
     pub creator: Addr,
     pub nft_contract: Addr,
     pub payment_token: Option<Addr>,


### PR DESCRIPTION
This PR introduces the following 2 improvements, which are aimed at helping UIs support the contracts:

1. The structure of a swap (`CW721Swap`) has been updated to include the swap id (which is also the swap's storage key).

```rs
/// New CW721Swap struct
pub struct CW721Swap {
    pub id: String, // New struct member
    pub creator: Addr,
    pub nft_contract: Addr,
    pub payment_token: Option<Addr>,
    pub token_id: String,
    pub expires: Expiration,
    pub price: Uint128,
    pub swap_type: SwapType,
}
```

This means all paginated queries now return a reference to the swap storage key, making it easier for UIs to support transacting with swaps (e.g. `ExecuteMsg::Finish`, `ExecuteMsg::Update`) populated from those queries.

2. The message for finishing a swap has been reduced to only the required data. Previously, users had to submit the full swap data but most of these struct members either were never used, or didn't need to be used.

```rs
/// New Finish msg; now only the swap id is required
pub struct FinishSwapMsg {
    pub id: String,
}
```
