### PR TITLE
Feature/filter by collection

### DIFF
--- a/contracts/cw721-marketplace-permissioned/schema/query_msg.json
+++ b/contracts/cw721-marketplace-permissioned/schema/query_msg.json
@@ -184,6 +184,16 @@
             "address": {
               "$ref": "#/definitions/Addr"
             },
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -225,6 +235,16 @@
         "swaps_by_price": {
           "type": "object",
           "properties": {
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -286,6 +306,16 @@
         "swaps_by_denom": {
           "type": "object",
           "properties": {
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -342,6 +372,16 @@
           "properties": {
             "cw20": {
               "type": "boolean"
+            },
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "limit": {
               "type": [

--- a/contracts/cw721-marketplace-permissioned/schema/schema.json
+++ b/contracts/cw721-marketplace-permissioned/schema/schema.json
@@ -439,6 +439,16 @@
                 "address": {
                   "$ref": "#/definitions/Addr"
                 },
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -480,6 +490,16 @@
             "swaps_by_price": {
               "type": "object",
               "properties": {
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -541,6 +561,16 @@
             "swaps_by_denom": {
               "type": "object",
               "properties": {
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -597,6 +627,16 @@
               "properties": {
                 "cw20": {
                   "type": "boolean"
+                },
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "limit": {
                   "type": [

--- a/contracts/cw721-marketplace-permissioned/src/contract.rs
+++ b/contracts/cw721-marketplace-permissioned/src/contract.rs
@@ -91,17 +91,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::ListingsOfToken { token_id, cw721, swap_type, page, limit } => {
             to_json_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
         }
-        QueryMsg::SwapsOf { address, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
+        QueryMsg::SwapsOf { address, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByPrice { min, max, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
+        QueryMsg::SwapsByPrice { min, max, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByDenom { payment_token, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
+        QueryMsg::SwapsByDenom { payment_token, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+        QueryMsg::SwapsByPaymentType { cw20, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, cw721, page, limit)?)
         }
         QueryMsg::Config {} => {
             to_json_binary(&query_config(deps)?)

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/pagination.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/pagination.rs
@@ -175,6 +175,7 @@ fn test_pagination() {
         QueryMsg::SwapsOf {
             address: cw721_owner.clone(),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -186,6 +187,7 @@ fn test_pagination() {
         QueryMsg::SwapsOf {
             address: cw721_owner.clone(),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -216,6 +218,7 @@ fn test_pagination() {
             min: Some(Uint128::from(0_u128)),
             max: Some(Uint128::from(1000000000000000000_u128)),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -228,6 +231,7 @@ fn test_pagination() {
             min: Some(Uint128::from(0_u128)),
             max: Some(Uint128::from(1000000000000000000_u128)),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -257,6 +261,7 @@ fn test_pagination() {
         QueryMsg::SwapsByDenom {
             payment_token: None,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -268,6 +273,7 @@ fn test_pagination() {
         QueryMsg::SwapsByDenom {
             payment_token: None,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -298,6 +304,7 @@ fn test_pagination() {
         QueryMsg::SwapsByPaymentType {
             cw20: false,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -309,6 +316,7 @@ fn test_pagination() {
         QueryMsg::SwapsByPaymentType {
             cw20: false,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }

--- a/contracts/cw721-marketplace-permissioned/src/msg.rs
+++ b/contracts/cw721-marketplace-permissioned/src/msg.rs
@@ -101,6 +101,7 @@ pub enum QueryMsg {
     SwapsOf { 
         address: Addr,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -109,6 +110,7 @@ pub enum QueryMsg {
         min: Option<Uint128>,
         max: Option<Uint128>,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -117,6 +119,7 @@ pub enum QueryMsg {
     SwapsByDenom {
         payment_token: Option<Addr>,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -124,6 +127,7 @@ pub enum QueryMsg {
     SwapsByPaymentType {
         cw20: bool,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },

--- a/contracts/cw721-marketplace/schema/query_msg.json
+++ b/contracts/cw721-marketplace/schema/query_msg.json
@@ -184,6 +184,16 @@
             "address": {
               "$ref": "#/definitions/Addr"
             },
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -225,6 +235,16 @@
         "swaps_by_price": {
           "type": "object",
           "properties": {
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -286,6 +306,16 @@
         "swaps_by_denom": {
           "type": "object",
           "properties": {
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "limit": {
               "type": [
                 "integer",
@@ -342,6 +372,16 @@
           "properties": {
             "cw20": {
               "type": "boolean"
+            },
+            "cw721": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "limit": {
               "type": [

--- a/contracts/cw721-marketplace/schema/schema.json
+++ b/contracts/cw721-marketplace/schema/schema.json
@@ -401,6 +401,16 @@
                 "address": {
                   "$ref": "#/definitions/Addr"
                 },
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -442,6 +452,16 @@
             "swaps_by_price": {
               "type": "object",
               "properties": {
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -503,6 +523,16 @@
             "swaps_by_denom": {
               "type": "object",
               "properties": {
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "limit": {
                   "type": [
                     "integer",
@@ -559,6 +589,16 @@
               "properties": {
                 "cw20": {
                   "type": "boolean"
+                },
+                "cw721": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "limit": {
                   "type": [

--- a/contracts/cw721-marketplace/src/contract.rs
+++ b/contracts/cw721-marketplace/src/contract.rs
@@ -88,17 +88,17 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::ListingsOfToken { token_id, cw721, swap_type, page, limit } => {
             to_json_binary(&query_swaps_of_token(deps, token_id, cw721, swap_type, page, limit)?)
         }
-        QueryMsg::SwapsOf { address, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, page, limit)?)
+        QueryMsg::SwapsOf { address, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_creator(deps, address, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByPrice { min, max, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, page, limit)?)
+        QueryMsg::SwapsByPrice { min, max, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_price(deps, min, max, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByDenom { payment_token, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, page, limit)?)
+        QueryMsg::SwapsByDenom { payment_token, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_denom(deps, payment_token, swap_type, cw721, page, limit)?)
         }
-        QueryMsg::SwapsByPaymentType { cw20, swap_type, page, limit } => {
-            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, page, limit)?)
+        QueryMsg::SwapsByPaymentType { cw20, swap_type, cw721, page, limit } => {
+            to_json_binary(&query_swaps_by_payment_type(deps, cw20, swap_type, cw721, page, limit)?)
         }
         QueryMsg::Config {} => {
             to_json_binary(&query_config(deps)?)

--- a/contracts/cw721-marketplace/src/integration_tests/pagination.rs
+++ b/contracts/cw721-marketplace/src/integration_tests/pagination.rs
@@ -175,6 +175,7 @@ fn test_pagination() {
         QueryMsg::SwapsOf {
             address: cw721_owner.clone(),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -186,6 +187,7 @@ fn test_pagination() {
         QueryMsg::SwapsOf {
             address: cw721_owner.clone(),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -216,6 +218,7 @@ fn test_pagination() {
             min: Some(Uint128::from(0_u128)),
             max: Some(Uint128::from(1000000000000000000_u128)),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -228,6 +231,7 @@ fn test_pagination() {
             min: Some(Uint128::from(0_u128)),
             max: Some(Uint128::from(1000000000000000000_u128)),
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -257,6 +261,7 @@ fn test_pagination() {
         QueryMsg::SwapsByDenom {
             payment_token: None,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -268,6 +273,7 @@ fn test_pagination() {
         QueryMsg::SwapsByDenom {
             payment_token: None,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }
@@ -298,6 +304,7 @@ fn test_pagination() {
         QueryMsg::SwapsByPaymentType {
             cw20: false,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: None,
             limit: None,
         }
@@ -309,6 +316,7 @@ fn test_pagination() {
         QueryMsg::SwapsByPaymentType {
             cw20: false,
             swap_type: Some(SwapType::Sale),
+            cw721: None,
             page: Some(1_u32),
             limit: None,
         }

--- a/contracts/cw721-marketplace/src/msg.rs
+++ b/contracts/cw721-marketplace/src/msg.rs
@@ -94,6 +94,7 @@ pub enum QueryMsg {
     SwapsOf { 
         address: Addr,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -102,6 +103,7 @@ pub enum QueryMsg {
         min: Option<Uint128>,
         max: Option<Uint128>,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -110,6 +112,7 @@ pub enum QueryMsg {
     SwapsByDenom {
         payment_token: Option<Addr>,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },
@@ -117,6 +120,7 @@ pub enum QueryMsg {
     SwapsByPaymentType {
         cw20: bool,
         swap_type: Option<SwapType>,
+        cw721: Option<Addr>,
         page: Option<u32>,
         limit: Option<u32>,
     },

--- a/contracts/cw721-marketplace/src/query.rs
+++ b/contracts/cw721-marketplace/src/query.rs
@@ -145,6 +145,7 @@ pub fn query_swaps_by_creator(
     deps: Deps, 
     address: Addr,
     swap_type: Option<SwapType>,
+    cw721: Option<Addr>,
     page: Option<u32>,
     limit: Option<u32>,
 ) -> StdResult<PageResult> {
@@ -153,15 +154,28 @@ pub fn query_swaps_by_creator(
         .range(deps.storage, None, None, Order::Ascending)
         .collect();
 
-    let results: Vec<CW721Swap> = swaps
-        .unwrap()
-        .into_iter()
-        .map(|t| t.1)
-        .filter(|item| {
-            item.creator == address
-            && item.swap_type == side
-        })
-        .collect();
+    let results: Vec<CW721Swap> = if let Some(contract) = cw721 {
+        swaps
+            .unwrap()
+            .into_iter()
+            .map(|t| t.1)
+            .filter(|item| {
+                item.creator == address
+                && item.swap_type == side
+                && item.nft_contract == contract
+            })
+            .collect()
+    } else {
+        swaps
+            .unwrap()
+            .into_iter()
+            .map(|t| t.1)
+            .filter(|item| {
+                item.creator == address
+                && item.swap_type == side
+            })
+            .collect()
+    };
 
     let paging: PageParams = calculate_page_params(page, limit, results.len() as u32)?;
     let res = PageResult {
@@ -178,6 +192,7 @@ pub fn query_swaps_by_price(
     min: Option<Uint128>, 
     max: Option<Uint128>, 
     swap_type: Option<SwapType>,
+    cw721: Option<Addr>,
     page: Option<u32>,
     limit: Option<u32>,
 ) -> StdResult<PageResult> {
@@ -188,7 +203,7 @@ pub fn query_swaps_by_price(
         .collect();
 
     // With Max range filter
-    let results: Vec<CW721Swap> = if let Some(max_value) = max {
+    let mut results: Vec<CW721Swap> = if let Some(max_value) = max {
         swaps
             .unwrap()
             .into_iter()
@@ -211,6 +226,18 @@ pub fn query_swaps_by_price(
             .collect()
     };
 
+    // If limited to a collection scope
+    results = if let Some(contract) = cw721 {
+        results
+            .into_iter()
+            .filter(|item| {
+                item.nft_contract == contract  
+            })
+            .collect()
+    } else {
+        results
+    };
+
     let paging: PageParams = calculate_page_params(page, limit, results.len() as u32)?;
     let res = PageResult {
         swaps: results[paging.start..paging.end].to_vec(),
@@ -225,6 +252,7 @@ pub fn query_swaps_by_denom(
     deps: Deps, 
     payment_token: Option<Addr>, 
     swap_type: Option<SwapType>,
+    cw721: Option<Addr>,
     page: Option<u32>,
     limit: Option<u32>,
 ) -> StdResult<PageResult> {
@@ -234,7 +262,7 @@ pub fn query_swaps_by_denom(
         .collect();
 
     // Requested cw20 denom
-    let results: Vec<CW721Swap> = if let Some(token_addr) = payment_token {
+    let mut results: Vec<CW721Swap> = if let Some(token_addr) = payment_token {
         swaps
             .unwrap()
             .into_iter()
@@ -257,6 +285,18 @@ pub fn query_swaps_by_denom(
             .collect()
     };
 
+    // If limited to a collection scope
+    results = if let Some(contract) = cw721 {
+        results
+            .into_iter()
+            .filter(|item| {
+                item.nft_contract == contract  
+            })
+            .collect()
+    } else {
+        results
+    };
+
     let paging: PageParams = calculate_page_params(page, limit, results.len() as u32)?;
     let res = PageResult {
         swaps: results[paging.start..paging.end].to_vec(),
@@ -271,6 +311,7 @@ pub fn query_swaps_by_payment_type(
     deps: Deps, 
     cw20: bool,
     swap_type: Option<SwapType>,
+    cw721: Option<Addr>,
     page: Option<u32>,
     limit: Option<u32>,
 ) -> StdResult<PageResult> {
@@ -280,7 +321,7 @@ pub fn query_swaps_by_payment_type(
         .collect();
 
     // cw20 swap
-    let results: Vec<CW721Swap> = if cw20 {
+    let mut results: Vec<CW721Swap> = if cw20 {
         swaps
             .unwrap()
             .into_iter()
@@ -301,6 +342,18 @@ pub fn query_swaps_by_payment_type(
                 && item.swap_type == side
             })
             .collect()
+    };
+
+    // If limited to a collection scope
+    results = if let Some(contract) = cw721 {
+        results
+            .into_iter()
+            .filter(|item| {
+                item.nft_contract == contract  
+            })
+            .collect()
+    } else {
+        results
     };
 
     let paging: PageParams = calculate_page_params(page, limit, results.len() as u32)?;


### PR DESCRIPTION
This PR adds the optional ability to limit the scope of queries to a particular collection contract for the multi-collection versions of the marketplace contract (`cw721-marketplace`, `cw721-marketplace-permissioned`)

The following query entry points will now accept an optional `cw721` address parameter to limit the scope:
- `QueryMsg::SwapsOf`
- `QueryMsg::SwapsByPrice`
- `QueryMsg::SwapsByDenom`
- `QueryMsg::SwapsByPaymentType`