### PR TITLE
Fee percentage fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build results
+/target
+/artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "autocfg"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "base16ct"
@@ -358,6 +373,7 @@ dependencies = [
  "cw20-base",
  "cw721",
  "cw721-base",
+ "rstest",
  "schemars",
  "serde",
  "thiserror",
@@ -378,6 +394,7 @@ dependencies = [
  "cw20-base",
  "cw721",
  "cw721-base",
+ "rstest",
  "schemars",
  "serde",
  "thiserror",
@@ -398,6 +415,7 @@ dependencies = [
  "cw20-base",
  "cw721",
  "cw721-base",
+ "rstest",
  "schemars",
  "serde",
  "thiserror",
@@ -523,6 +541,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +656,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -615,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +750,18 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -693,6 +830,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +872,44 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.57",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -745,6 +955,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -829,6 +1045,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cw721 = "0.13.4"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1.0"
+rstest = "0.18.2"
 
 [workspace.metadata.scripts]
 schema = """

--- a/contracts/cw721-marketplace-permissioned/Cargo.toml
+++ b/contracts/cw721-marketplace-permissioned/Cargo.toml
@@ -50,3 +50,4 @@ utils = { path = "../../utils" }
 [dev-dependencies]
 cosmwasm-schema.workspace = true
 cw-multi-test.workspace = true
+rstest.workspace = true

--- a/contracts/cw721-marketplace-permissioned/src/execute.rs
+++ b/contracts/cw721-marketplace-permissioned/src/execute.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
 };
 
 use cw20::Cw20ExecuteMsg;
+use utils::FeeSplit;
 use utils::prelude::{CW721Swap, SwapType};
 
 use crate::state::{Config, CONFIG, SWAPS};
@@ -147,9 +148,9 @@ pub fn execute_finish(
             .filter(|coin| { coin.denom == config.denom })
             .collect();
 
-        fee_split(&deps, funds[0].amount).unwrap()
-    } else { 
-        fee_split(&deps, swap.price).unwrap()
+        fee_split(&deps, funds[0].amount).unwrap_or(FeeSplit::only_seller(funds[0].amount))
+    } else {
+        fee_split(&deps, swap.price).unwrap_or(FeeSplit::only_seller(swap.price))
     };
 
     // Do swap transfer

--- a/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-permissioned/src/integration_tests/fees.rs
@@ -11,6 +11,7 @@ use cw721_base::{
     msg::ExecuteMsg as Cw721ExecuteMsg, Extension, MintMsg, msg::QueryMsg as Cw721QueryMsg,
 };
 use cw721::OwnerOfResponse;
+use rstest::rstest;
 use utils::prelude::PageResult;
 
 use crate::integration_tests::util::{
@@ -25,10 +26,19 @@ static DENOM: &str = "aarch";
 
 // Swap buyer pays with ARCH
 // ensuring marketplace fees are respected
-#[test]
-fn test_fees_native() {
+#[rstest]
+#[case(10, false, 20, 2)]
+#[case(100, true, 22, 22)]
+#[case(1000, true, 15, 150)]
+#[case(10000, true, 30, 3000)]
+#[case(100000, true, 5, 5000)]
+#[case(u128::MAX, false, 10, 34028236692093846346337460743176821145)]
+fn test_fees_native(#[case] amount: u128, #[case] in_arch: bool, #[case] fee_split: u64, #[case] expected: u128) {
     let mut app = mock_app();
-    
+
+    let amount = if in_arch { amount * 10u128.pow(18) } else { amount };
+    let expected = if in_arch { expected * 10u128.pow(18) } else { expected };
+
     // Swap owner deploys
     let swap_admin = Addr::unchecked("swap_deployer");
     // cw721_owner owns the cw721
@@ -40,14 +50,14 @@ fn test_fees_native() {
     let nft = create_cw721(&mut app, &cw721_owner);
     
     // swap_admin creates the swap contract 
-    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), 1_u64); // 1% Marketplace fees
+    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), fee_split); // 1% Marketplace fees
     let swap_inst = swap.clone();
     
     // Mint native to `arch_owner`
     mint_native(
         &mut app,
         arch_owner.to_string(),
-        Uint128::from(10000000000000000000_u128), // 10 ARCH as aarch
+        Uint128::from(amount), // 10 ARCH as aarch
     );
 
     // cw721_owner mints a cw721 
@@ -70,7 +80,7 @@ fn test_fees_native() {
         payment_token: None,
         token_id: token_id.clone(),    
         expires: Expiration::from(cw20::Expiration::AtHeight(384798573487439743)),
-        price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
+        price: Uint128::from(amount), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
     let finish_msg = FinishSwapMsg {
@@ -100,7 +110,7 @@ fn test_fees_native() {
             &ExecuteMsg::Finish(finish_msg), 
             &[Coin {
                 denom: String::from(DENOM),
-                amount: Uint128::from(1000000000000000000_u128)
+                amount: Uint128::from(amount)
             }]
         )
         .unwrap();
@@ -133,15 +143,15 @@ fn test_fees_native() {
 
     // cw721_owner has received the ARCH amount
     let balance_query: Coin = bank_query(&mut app, &cw721_owner);
-    assert_eq!(balance_query.amount, Uint128::from(990000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(amount - expected));
     
     // swap_inst has retained its fee
     let balance_query: Coin = bank_query(&mut app, &swap_inst);
-    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(expected));
 
     // swap_admin can withdraw native fees
     let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(10000000000000000_u128), 
+        amount: Uint128::from(expected),
         denom: String::from(DENOM),
         payment_token: None,
     };
@@ -156,15 +166,24 @@ fn test_fees_native() {
     
     // swap_admin received its withdrawn fees
     let balance_query: Coin = bank_query(&mut app, &swap_admin);
-    assert_eq!(balance_query.amount, Uint128::from(10000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(expected));
 }
 
 // Receive cw20 tokens and release upon approval
 // ensuring marketplace fees are respected
-#[test]
-fn test_fees_cw20() {
+#[rstest]
+#[case(10, false, 20, 2)]
+#[case(100, true, 22, 22)]
+#[case(1000, true, 15, 150)]
+#[case(10000, true, 30, 3000)]
+#[case(100000, true, 5, 5000)]
+#[case(u128::MAX, false, 10, 34028236692093846346337460743176821145)]
+fn test_fees_cw20(#[case] amount: u128, #[case] in_arch: bool, #[case] fee_split: u64, #[case] expected: u128) {
     let mut app = mock_app();
-    
+
+    let amount = if in_arch { amount * 10u128.pow(18) } else { amount };
+    let expected = if in_arch { expected * 10u128.pow(18) } else { expected };
+
     // Swap owner deploys
     let swap_admin = Addr::unchecked("swap_deployer");
     // cw721_owner owns the cw721
@@ -176,7 +195,7 @@ fn test_fees_cw20() {
     let nft = create_cw721(&mut app, &cw721_owner);
     
     // swap_admin creates the swap contract 
-    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), 1_u64); // 1% Marketplace fees
+    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), fee_split); // 1% Marketplace fees
     let swap_inst = swap.clone();
     
     // cw20_owner creates a cw20 coin
@@ -185,7 +204,7 @@ fn test_fees_cw20() {
         &cw20_owner,
         "testcw".to_string(),
         "tscw".to_string(),
-        Uint128::from(100000_u32)
+        Uint128::from(amount)
     );
     let cw20_inst = cw20.clone();
 
@@ -209,7 +228,7 @@ fn test_fees_cw20() {
         payment_token: Some(Addr::unchecked(cw20.clone())),
         token_id: token_id.clone(),    
         expires: Expiration::from(cw20::Expiration::AtHeight(384798573487439743)),
-        price: Uint128::from(100000_u32),
+        price: Uint128::from(amount),
         swap_type: SwapType::Sale,
     };
     let finish_msg = FinishSwapMsg {
@@ -234,7 +253,7 @@ fn test_fees_cw20() {
     // cw721 buyer (cw20_owner) must approve swap contract to spend their cw20
     let cw20_approve_msg = Cw20ExecuteMsg::IncreaseAllowance {
         spender: swap.to_string(),
-        amount:  Uint128::from(100000_u32),
+        amount:  Uint128::from(amount),
         expires: None,
     };
     let _res = app
@@ -265,7 +284,7 @@ fn test_fees_cw20() {
             address: cw721_owner.to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(99000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(amount - expected));
 
     // swap_inst has retained its fee
     let balance_query: BalanceResponse = query(
@@ -275,11 +294,11 @@ fn test_fees_cw20() {
             address: swap_inst.clone().to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(expected));
 
     // swap_admin can withdraw cw20 fees
     let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(1000_u32),
+        amount: Uint128::from(expected),
         denom: String::from(DENOM),
         payment_token: Some(cw20_inst.clone()),
     };
@@ -300,5 +319,5 @@ fn test_fees_cw20() {
             address: swap_admin.to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(1000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(expected));
 }

--- a/contracts/cw721-marketplace-permissioned/src/utils.rs
+++ b/contracts/cw721-marketplace-permissioned/src/utils.rs
@@ -9,6 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
+use utils::fee_percentage;
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -260,11 +261,4 @@ pub fn fee_split(
         seller,
     };
     Ok(result)
-}
-
-pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
-    let share = Decimal::percent(share_percent);
-    let amount_decimal = Decimal::from_atomics(amount, 0).unwrap();
-    let fee = amount_decimal * share;
-    fee.to_uint_floor()
 }

--- a/contracts/cw721-marketplace-permissioned/src/utils.rs
+++ b/contracts/cw721-marketplace-permissioned/src/utils.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_json, 
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, DepsMut, Env, from_json,
     QueryRequest, to_json_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
@@ -9,7 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
-use utils::fee_percentage;
+use utils::{fee_percentage, FeeSplit};
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -26,13 +26,6 @@ pub struct PageParams {
     pub end: usize,
     pub page: u32,
     pub total: u128,
-}
-
-// Fee split result
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct FeeSplit {
-    pub marketplace: Uint128,
-    pub seller: Uint128,
 }
 
 // Read utils

--- a/contracts/cw721-marketplace-single-collection/Cargo.toml
+++ b/contracts/cw721-marketplace-single-collection/Cargo.toml
@@ -50,3 +50,4 @@ utils = { path = "../../utils" }
 [dev-dependencies]
 cosmwasm-schema.workspace = true
 cw-multi-test.workspace = true
+rstest.workspace = true

--- a/contracts/cw721-marketplace-single-collection/src/execute.rs
+++ b/contracts/cw721-marketplace-single-collection/src/execute.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
 };
 
 use cw20::Cw20ExecuteMsg;
+use utils::FeeSplit;
 use utils::prelude::{CW721Swap, SwapType};
 
 use crate::state::{Config, CONFIG, SWAPS};
@@ -138,9 +139,9 @@ pub fn execute_finish(
             .filter(|coin| { coin.denom == config.denom })
             .collect();
 
-        fee_split(&deps, funds[0].amount).unwrap()
-    } else { 
-        fee_split(&deps, swap.price).unwrap()
+        fee_split(&deps, funds[0].amount).unwrap_or(FeeSplit::only_seller(funds[0].amount))
+    } else {
+        fee_split(&deps, swap.price).unwrap_or(FeeSplit::only_seller(swap.price))
     };
 
     // Do swap transfer

--- a/contracts/cw721-marketplace-single-collection/src/integration_tests/fees.rs
+++ b/contracts/cw721-marketplace-single-collection/src/integration_tests/fees.rs
@@ -11,6 +11,7 @@ use cw721_base::{
     msg::ExecuteMsg as Cw721ExecuteMsg, Extension, MintMsg, msg::QueryMsg as Cw721QueryMsg,
 };
 use cw721::OwnerOfResponse;
+use rstest::rstest;
 use utils::prelude::PageResult;
 
 use crate::integration_tests::util::{
@@ -25,10 +26,19 @@ static DENOM: &str = "aarch";
 
 // Swap buyer pays with ARCH
 // ensuring marketplace fees are respected
-#[test]
-fn test_fees_native() {
+#[rstest]
+#[case(10, false, 20, 2)]
+#[case(100, true, 22, 22)]
+#[case(1000, true, 15, 150)]
+#[case(10000, true, 30, 3000)]
+#[case(100000, true, 5, 5000)]
+#[case(u128::MAX, false, 10, 34028236692093846346337460743176821145)]
+fn test_fees_native(#[case] amount: u128, #[case] in_arch: bool, #[case] fee_split: u64, #[case] expected: u128) {
     let mut app = mock_app();
-    
+
+    let amount = if in_arch { amount * 10u128.pow(18) } else { amount };
+    let expected = if in_arch { expected * 10u128.pow(18) } else { expected };
+
     // Swap owner deploys
     let swap_admin = Addr::unchecked("swap_deployer");
     // cw721_owner owns the cw721
@@ -40,14 +50,14 @@ fn test_fees_native() {
     let nft = create_cw721(&mut app, &cw721_owner);
     
     // swap_admin creates the swap contract 
-    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), 3_u64); // 3% Marketplace fees
+    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), fee_split); // 3% Marketplace fees
     let swap_inst = swap.clone();
     
     // Mint native to `arch_owner`
     mint_native(
         &mut app,
         arch_owner.to_string(),
-        Uint128::from(10000000000000000000_u128), // 10 ARCH as aarch
+        Uint128::from(amount), // 10 ARCH as aarch
     );
 
     // cw721_owner mints a cw721 
@@ -69,7 +79,7 @@ fn test_fees_native() {
         payment_token: None,
         token_id: token_id.clone(),    
         expires: Expiration::from(cw20::Expiration::AtHeight(384798573487439743)),
-        price: Uint128::from(1000000000000000000_u128), // 1 ARCH as aarch
+        price: Uint128::from(amount), // 1 ARCH as aarch
         swap_type: SwapType::Sale,
     };
     let finish_msg = FinishSwapMsg {
@@ -99,7 +109,7 @@ fn test_fees_native() {
             &ExecuteMsg::Finish(finish_msg), 
             &[Coin {
                 denom: String::from(DENOM),
-                amount: Uint128::from(1000000000000000000_u128)
+                amount: Uint128::from(amount)
             }]
         )
         .unwrap();
@@ -131,15 +141,15 @@ fn test_fees_native() {
 
     // cw721_owner has received the ARCH amount
     let balance_query: Coin = bank_query(&mut app, &cw721_owner);
-    assert_eq!(balance_query.amount, Uint128::from(970000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(amount - expected));
     
     // swap_inst has retained its fee
     let balance_query: Coin = bank_query(&mut app, &swap_inst);
-    assert_eq!(balance_query.amount, Uint128::from(30000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(expected));
 
     // swap_admin can withdraw native fees
     let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(30000000000000000_u128), 
+        amount: Uint128::from(expected),
         denom: String::from(DENOM),
         payment_token: None,
     };
@@ -154,15 +164,24 @@ fn test_fees_native() {
     
     // swap_admin received its withdrawn fees
     let balance_query: Coin = bank_query(&mut app, &swap_admin);
-    assert_eq!(balance_query.amount, Uint128::from(30000000000000000_u128));
+    assert_eq!(balance_query.amount, Uint128::from(expected));
 }
 
 // Receive cw20 tokens and release upon approval
 // ensuring marketplace fees are respected
-#[test]
-fn test_fees_cw20() {
+#[rstest]
+#[case(10, false, 20, 2)]
+#[case(100, true, 22, 22)]
+#[case(1000, true, 15, 150)]
+#[case(10000, true, 30, 3000)]
+#[case(100000, true, 5, 5000)]
+#[case(u128::MAX, false, 10, 34028236692093846346337460743176821145)]
+fn test_fees_cw20(#[case] amount: u128, #[case] in_arch: bool, #[case] fee_split: u64, #[case] expected: u128) {
     let mut app = mock_app();
-    
+
+    let amount = if in_arch { amount * 10u128.pow(18) } else { amount };
+    let expected = if in_arch { expected * 10u128.pow(18) } else { expected };
+
     // Swap owner deploys
     let swap_admin = Addr::unchecked("swap_deployer");
     // cw721_owner owns the cw721
@@ -174,7 +193,7 @@ fn test_fees_cw20() {
     let nft = create_cw721(&mut app, &cw721_owner);
     
     // swap_admin creates the swap contract 
-    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), 3_u64); // 3% Marketplace fees
+    let swap = create_swap_with_fees(&mut app, &swap_admin, nft.clone(), fee_split); // 3% Marketplace fees
     let swap_inst = swap.clone();
     
     // cw20_owner creates a cw20 coin
@@ -183,7 +202,7 @@ fn test_fees_cw20() {
         &cw20_owner,
         "testcw".to_string(),
         "tscw".to_string(),
-        Uint128::from(100000_u32)
+        Uint128::from(amount)
     );
     let cw20_inst = cw20.clone();
 
@@ -206,7 +225,7 @@ fn test_fees_cw20() {
         payment_token: Some(Addr::unchecked(cw20.clone())),
         token_id: token_id.clone(),    
         expires: Expiration::from(cw20::Expiration::AtHeight(384798573487439743)),
-        price: Uint128::from(100000_u32),
+        price: Uint128::from(amount),
         swap_type: SwapType::Sale,
     };
     let finish_msg = FinishSwapMsg {
@@ -231,7 +250,7 @@ fn test_fees_cw20() {
     // cw721 buyer (cw20_owner) must approve swap contract to spend their cw20
     let cw20_approve_msg = Cw20ExecuteMsg::IncreaseAllowance {
         spender: swap.to_string(),
-        amount:  Uint128::from(100000_u32),
+        amount:  Uint128::from(amount),
         expires: None,
     };
     let _res = app
@@ -262,7 +281,7 @@ fn test_fees_cw20() {
             address: cw721_owner.to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(97000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(amount - expected));
 
     // swap_inst has retained its fee
     let balance_query: BalanceResponse = query(
@@ -272,11 +291,11 @@ fn test_fees_cw20() {
             address: swap_inst.clone().to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(3000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(expected));
 
     // swap_admin can withdraw cw20 fees
     let withdraw_msg = WithdrawMsg {
-        amount: Uint128::from(3000_u32),
+        amount: Uint128::from(expected),
         denom: String::from(DENOM),
         payment_token: Some(cw20_inst.clone()),
     };
@@ -297,5 +316,5 @@ fn test_fees_cw20() {
             address: swap_admin.to_string()
         }
     ).unwrap();
-    assert_eq!(balance_query.balance, Uint128::from(3000_u32));
+    assert_eq!(balance_query.balance, Uint128::from(expected));
 }

--- a/contracts/cw721-marketplace-single-collection/src/utils.rs
+++ b/contracts/cw721-marketplace-single-collection/src/utils.rs
@@ -9,6 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
+use utils::fee_percentage;
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -260,11 +261,4 @@ pub fn fee_split(
         seller,
     };
     Ok(result)
-}
-
-pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
-    let share = Decimal::percent(share_percent);
-    let amount_decimal = Decimal::from_atomics(amount, 0).unwrap();
-    let fee = amount_decimal * share;
-    fee.to_uint_floor()
 }

--- a/contracts/cw721-marketplace-single-collection/src/utils.rs
+++ b/contracts/cw721-marketplace-single-collection/src/utils.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_json, 
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, DepsMut, Env, from_json,
     QueryRequest, to_json_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
@@ -9,7 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
-use utils::fee_percentage;
+use utils::{fee_percentage, FeeSplit};
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -26,13 +26,6 @@ pub struct PageParams {
     pub end: usize,
     pub page: u32,
     pub total: u128,
-}
-
-// Fee split result
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct FeeSplit {
-    pub marketplace: Uint128,
-    pub seller: Uint128,
 }
 
 // Read utils

--- a/contracts/cw721-marketplace/Cargo.toml
+++ b/contracts/cw721-marketplace/Cargo.toml
@@ -50,3 +50,4 @@ utils = { path = "../../utils" }
 [dev-dependencies]
 cosmwasm-schema.workspace = true
 cw-multi-test.workspace = true
+rstest.workspace = true

--- a/contracts/cw721-marketplace/src/execute.rs
+++ b/contracts/cw721-marketplace/src/execute.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
 };
 
 use cw20::Cw20ExecuteMsg;
+use utils::FeeSplit;
 use utils::prelude::{CW721Swap, SwapType};
 
 use crate::state::{Config, CONFIG, SWAPS};
@@ -139,9 +140,9 @@ pub fn execute_finish(
             .filter(|coin| { coin.denom == config.denom })
             .collect();
         
-        fee_split(&deps, funds[0].amount).unwrap()
+        fee_split(&deps, funds[0].amount).unwrap_or(FeeSplit::only_seller(funds[0].amount))
     } else {
-        fee_split(&deps, swap.price).unwrap()
+        fee_split(&deps, swap.price).unwrap_or(FeeSplit::only_seller(swap.price))
     };
 
     // Do swap transfer

--- a/contracts/cw721-marketplace/src/utils.rs
+++ b/contracts/cw721-marketplace/src/utils.rs
@@ -9,6 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
+use utils::fee_percentage;
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -260,11 +261,4 @@ pub fn fee_split(
         seller,
     };
     Ok(result)
-}
-
-pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
-    let share = Decimal::percent(share_percent);
-    let amount_decimal = Decimal::from_atomics(amount, 0).unwrap();
-    let fee = amount_decimal * share;
-    fee.to_uint_floor()
 }

--- a/contracts/cw721-marketplace/src/utils.rs
+++ b/contracts/cw721-marketplace/src/utils.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
-    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Decimal, DepsMut, Env, from_json, 
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, DepsMut, Env, from_json,
     QueryRequest, to_json_binary, StdError, StdResult, Uint128, WasmMsg, WasmQuery,
 };
 
@@ -9,7 +9,7 @@ use cw20::Cw20ExecuteMsg;
 use cw721_base::{QueryMsg as Cw721QueryMsg};
 use cw721::OwnerOfResponse;
 use cw721_base::{msg::ExecuteMsg as Cw721ExecuteMsg, Extension};
-use utils::fee_percentage;
+use utils::{fee_percentage, FeeSplit};
 use utils::prelude::CW721Swap;
 
 use crate::state::{CONFIG};
@@ -26,13 +26,6 @@ pub struct PageParams {
     pub end: usize,
     pub page: u32,
     pub total: u128,
-}
-
-// Fee split result
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct FeeSplit {
-    pub marketplace: Uint128,
-    pub seller: Uint128,
 }
 
 // Read utils

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -14,7 +14,8 @@ pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
     let amount = Uint256::from_uint128(amount) * Uint256::from_u128(100);
 
     // Get percentage and divide by 10 ** 4 (both decimal spots added up)
-    let fee = (amount * Uint256::from(share_percent)) / Uint256::from(10000u16);
+    let fee = (amount * Uint256::from(share_percent))
+        .checked_div(Uint256::from(10000u16)).unwrap_or(Uint256::zero());
 
     // We can safely unwrap since we've tested against u128::MAX
     fee.try_into().unwrap()

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Decimal, Uint128, Uint256};
+use cosmwasm_std::{Uint128, Uint256};
 
 mod swap;
 mod query;
@@ -16,7 +16,7 @@ pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
     // Get percentage and divide by 10 ** 4 (both decimal spots added up)
     let fee = (amount * Uint256::from(share_percent)) / Uint256::from(10000u16);
 
-    // We can safely unwrap since weve tested against u128::MAX
+    // We can safely unwrap since we've tested against u128::MAX
     fee.try_into().unwrap()
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -37,8 +37,20 @@ mod test {
         let expected = Uint128::new(50000000000000000000000000000000000000);
         assert_eq!(fee_percentage(amount, 50), expected);
 
+        // Testing for overflow
         fee_percentage(Uint128::MAX, 1);
         fee_percentage(Uint128::MAX, 0);
         fee_percentage(Uint128::MAX, 100);
+
+        // Testing for underflow
+        assert_eq!(fee_percentage(Uint128::one(), 0), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::one(), 1), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::one(), 10), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::one(), 100), Uint128::one());
+
+        assert_eq!(fee_percentage(Uint128::zero(), 0), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::zero(), 1), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::zero(), 10), Uint128::zero());
+        assert_eq!(fee_percentage(Uint128::zero(), 100), Uint128::zero());
     }
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,6 @@
 use cosmwasm_std::{Uint128, Uint256};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 mod swap;
 mod query;
@@ -7,6 +9,22 @@ pub mod prelude {
     pub use crate::swap::{CW721Swap, SwapType};
     pub use crate::query::{PageResult, ListResponse, DetailsResponse};
     pub use crate::fee_percentage;
+}
+
+// Fee split result
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct FeeSplit {
+    pub marketplace: Uint128,
+    pub seller: Uint128,
+}
+
+impl FeeSplit {
+    pub fn only_seller(amount: Uint128) -> Self {
+        Self {
+            marketplace: Uint128::zero(),
+            seller: amount
+        }
+    }
 }
 
 pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,7 +1,44 @@
+use cosmwasm_std::{Decimal, Uint128, Uint256};
+
 mod swap;
 mod query;
 
 pub mod prelude {
     pub use crate::swap::{CW721Swap, SwapType};
     pub use crate::query::{PageResult, ListResponse, DetailsResponse};
+    pub use crate::fee_percentage;
+}
+
+pub fn fee_percentage(amount: Uint128, share_percent: u64) -> Uint128 {
+    // Allocate extra space for the two decimal places
+    let amount = Uint256::from_uint128(amount) * Uint256::from_u128(100);
+
+    // Get percentage and divide by 10 ** 4 (both decimal spots added up)
+    let fee = (amount * Uint256::from(share_percent)) / Uint256::from(10000u16);
+
+    // We can safely unwrap since weve tested against u128::MAX
+    fee.try_into().unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use cosmwasm_std::Uint128;
+    use crate::fee_percentage;
+
+    #[test]
+    fn fee_percentage_overflow() {
+        // Test small number
+        let amount = Uint128::new(123456);
+        let expected = Uint128::new(43209);
+        assert_eq!(fee_percentage(amount, 35), expected);
+
+        // Test largest number
+        let amount = Uint128::new(100000000000000000000000000000000000000);
+        let expected = Uint128::new(50000000000000000000000000000000000000);
+        assert_eq!(fee_percentage(amount, 50), expected);
+
+        fee_percentage(Uint128::MAX, 1);
+        fee_percentage(Uint128::MAX, 0);
+        fee_percentage(Uint128::MAX, 100);
+    }
 }


### PR DESCRIPTION
The main issue from the bug came from Decimal using `u128` internally and it allocating 10^18 zeroes for decimals, meaning that `u128::MAX` will always give you an overflow error. The solution to this is allocating extra space by doing the operations under `Uint256` since we only really need 10**4 extra spaces on top of the max u128 capacity.